### PR TITLE
HIP-18 add missing response code 

### DIFF
--- a/src/main/proto/ResponseCode.proto
+++ b/src/main/proto/ResponseCode.proto
@@ -252,5 +252,5 @@ enum ResponseCodeEnum {
   CUSTOM_FEES_ARE_MARKED_IMMUTABLE = 240; // Once custom fees are marked as immutable, they can never be changed (or made mutable again)
   CUSTOM_FEE_OUTSIDE_NUMERIC_RANGE = 241; // A fractional custom fee exceeded the range of a 64-bit signed integer
   INVALID_CUSTOM_FRACTIONAL_FEES_SUM = 242; // The sum of all custom fractional fees must be strictly less than 1
-  FRACTIONAL_FEES_MIN_GREATER_THAN_MAX = 243; // Fractional custom fees minimumAmount must be less than or equal to maximumAmount
+  FRACTIONAL_FEES_MAX_AMOUNT_LESS_THAN_MIN_AMOUNT = 243; // Fractional custom fees maximumAmount must be greater than or equal to minimumAmount
 }

--- a/src/main/proto/ResponseCode.proto
+++ b/src/main/proto/ResponseCode.proto
@@ -252,5 +252,5 @@ enum ResponseCodeEnum {
   CUSTOM_FEES_ARE_MARKED_IMMUTABLE = 240; // Once custom fees are marked as immutable, they can never be changed (or made mutable again)
   CUSTOM_FEE_OUTSIDE_NUMERIC_RANGE = 241; // A fractional custom fee exceeded the range of a 64-bit signed integer
   INVALID_CUSTOM_FRACTIONAL_FEES_SUM = 242; // The sum of all custom fractional fees must be strictly less than 1
-  FRACTIONAL_FEES_MAX_AMOUNT_LESS_THAN_MIN_AMOUNT = 243; // Fractional custom fees maximumAmount must be greater than or equal to minimumAmount
+  FRACTIONAL_FEE_MAX_AMOUNT_LESS_THAN_MIN_AMOUNT = 243; // Each fractional custom fee must have its maximum_amount, if specified, at least its minimum_amount
 }

--- a/src/main/proto/ResponseCode.proto
+++ b/src/main/proto/ResponseCode.proto
@@ -252,4 +252,5 @@ enum ResponseCodeEnum {
   CUSTOM_FEES_ARE_MARKED_IMMUTABLE = 240; // Once custom fees are marked as immutable, they can never be changed (or made mutable again)
   CUSTOM_FEE_OUTSIDE_NUMERIC_RANGE = 241; // A fractional custom fee exceeded the range of a 64-bit signed integer
   INVALID_CUSTOM_FRACTIONAL_FEES_SUM = 242; // The sum of all custom fractional fees must be strictly less than 1
+  FRACTIONAL_FEES_MIN_GREATER_THAN_MAX = 243; // Fractional custom fees minimumAmount must be less than or equal to maximumAmount
 }


### PR DESCRIPTION
**PR in [Hedera protobufs](https://github.com/hashgraph/hedera-protobufs/pull/46)**

**Description**:
When the fractional custom fee `maximumAmount` is less than `minimumAmount`, add a new response code `FRACTIONAL_FEE_MAX_AMOUNT_LESS_THAN_MIN_AMOUNT`

**List of changes**:
Added `FRACTIONAL_FEE_MAX_AMOUNT_LESS_THAN_MIN_AMOUNT` to `ResponseCode.proto`

**Related issue(s)**:
Fixes #72 

**Checklist**

- [x] Documentation added

