### PR TITLE
Include response codes, bump Netty version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <protobuf-java.version>3.8.0</protobuf-java.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <grpc.version>1.39.0</grpc.version>
-    <netty.version>4.1.65.Final</netty.version>
+    <netty.version>4.1.66.Final</netty.version>
 
     <maven-jar.version>3.2.0</maven-jar.version>
     <maven-source.version>3.2.0</maven-source.version>

--- a/src/main/proto/ResponseCode.proto
+++ b/src/main/proto/ResponseCode.proto
@@ -240,7 +240,7 @@ enum ResponseCodeEnum {
   BATCH_SIZE_LIMIT_EXCEEDED = 228; // Repeated operations count exceeds the limit
   INVALID_QUERY_RANGE = 229; // The range of data to be gathered is out of the set boundaries
   FRACTION_DIVIDES_BY_ZERO = 230; // A custom fractional fee set a denominator of zero
-  INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE = 231; // The transaction payer could not afford a custom fee
+  INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE = 231 [deprecated = true]; // The transaction payer could not afford a custom fee
   CUSTOM_FEES_LIST_TOO_LONG = 232; // More than 10 custom fees were specified
   INVALID_CUSTOM_FEE_COLLECTOR = 233; // Any of the feeCollector accounts for customFees is invalid
   INVALID_TOKEN_ID_IN_CUSTOM_FEES = 234; // Any of the token Ids in customFees is invalid
@@ -268,4 +268,6 @@ enum ResponseCodeEnum {
   PAYER_ACCOUNT_DELETED = 256; // The payer account has been marked as deleted
   CUSTOM_FEE_CHARGING_EXCEEDED_MAX_RECURSION_DEPTH = 257; // The reference chain of custom fees for a transferred token exceeded the maximum length of 2
   CUSTOM_FEE_CHARGING_EXCEEDED_MAX_ACCOUNT_AMOUNTS = 258; // More than 20 balance adjustments were to satisfy a CryptoTransfer and its implied custom fee payments
+  INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE = 259; // The sender account in the token transfer transaction could not afford a custom fee
+  SERIAL_NUMBER_LIMIT_REACHED = 260; // Currently no more than 4,294,967,295 NFTs may be minted for a given unique token type
 }


### PR DESCRIPTION
- Bump Netty version to `4.1.66.Final`.
- Sync latest response codes from _hedera-protobufs/_ repo.
