### PR TITLE
Add startTime field to Freeze txn and deprecate start/end hour/min.

### DIFF
--- a/src/main/proto/Freeze.proto
+++ b/src/main/proto/Freeze.proto
@@ -31,10 +31,11 @@ import "BasicTypes.proto";
 
 /* Set the freezing period in which the platform will stop creating events and accepting transactions. This is used before safely shut down the platform for maintenance. */
 message FreezeTransactionBody {
-    int32 startHour = 1; // The start hour (in UTC time), a value between 0 and 23
-    int32 startMin = 2; // The start minute (in UTC time), a value between 0 and 59
-    int32 endHour = 3; // The end hour (in UTC time), a value between 0 and 23
-    int32 endMin = 4; // The end minute (in UTC time), a value between 0 and 59
+    int32 startHour = 1 [deprecated=true]; // The start hour (in UTC time), a value between 0 and 23
+    int32 startMin = 2 [deprecated=true]; // The start minute (in UTC time), a value between 0 and 59
+    int32 endHour = 3 [deprecated=true]; // The end hour (in UTC time), a value between 0 and 23
+    int32 endMin = 4 [deprecated=true]; // The end minute (in UTC time), a value between 0 and 59
     FileID updateFile = 5; // The ID of the file needs to be updated during a freeze transaction
     bytes fileHash = 6; // The hash value of the file, used to verify file content before performing freeze and update
+    Timestamp startTime = 7; // the freeze start Timestamp
 }


### PR DESCRIPTION
**Description**:

This PR deprecates freeze transaction body's startHour, startMin, endHour, and endMin. It also introduce a new field startTime of Timestamp (Instant) to specify when freeze should start.

**Related issue(s)**:

Fixes #79
