### PR TITLE
Add a bool field to allow fractional fee to be charged to sender or receiver.

### DIFF
--- a/src/main/proto/CustomFees.proto
+++ b/src/main/proto/CustomFees.proto
@@ -34,7 +34,7 @@ message FractionalFee {
   Fraction fractional_amount = 1; // The fraction of the transferred units to assess as a fee
   int64 minimum_amount = 2; // The minimum amount to assess
   int64 maximum_amount = 3; // The maximum amount to assess (zero implies no maximum)
-  bool netOfTransfers = 4; // If true, assesses the fee to the sender, so the receiver gets the full amount from the token transfer list, and the sender is charged an additional fee; if false, the receiver does NOT get the full amount, but only what is left over after paying the fractional fee
+  bool net_of_transfers = 4; // If true, assesses the fee to the sender, so the receiver gets the full amount from the token transfer list, and the sender is charged an additional fee; if false, the receiver does NOT get the full amount, but only what is left over after paying the fractional fee
 }
 
 /* A fixed number of units (hbar or token) to assess as a fee during a CryptoTransfer 

--- a/src/main/proto/CustomFees.proto
+++ b/src/main/proto/CustomFees.proto
@@ -34,6 +34,7 @@ message FractionalFee {
   Fraction fractional_amount = 1; // The fraction of the transferred units to assess as a fee
   int64 minimum_amount = 2; // The minimum amount to assess
   int64 maximum_amount = 3; // The maximum amount to assess (zero implies no maximum)
+  bool netOfTransfers = 4; // If true, assesses the fee to the sender, so the receiver gets the full amount from the token transfer list, and the sender is charged an additional fee; if false, the receiver does NOT get the full amount, but only what is left over after paying the fractional fee
 }
 
 /* A fixed number of units (hbar or token) to assess as a fee during a CryptoTransfer 

--- a/src/main/proto/ResponseCode.proto
+++ b/src/main/proto/ResponseCode.proto
@@ -269,5 +269,5 @@ enum ResponseCodeEnum {
   CUSTOM_FEE_CHARGING_EXCEEDED_MAX_RECURSION_DEPTH = 257; // The reference chain of custom fees for a transferred token exceeded the maximum length of 2
   CUSTOM_FEE_CHARGING_EXCEEDED_MAX_ACCOUNT_AMOUNTS = 258; // More than 20 balance adjustments were to satisfy a CryptoTransfer and its implied custom fee payments
   INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE = 259; // The sender account in the token transfer transaction could not afford a custom fee
-  SERIAL_NUMBER_LIMIT_REACHED = 260; // Currently no more than 4,294,967,295 NFTs may be minted for a given unique token type
+
 }


### PR DESCRIPTION
**Description**:

This PR adds one bool field to allow the user to decide the fractional custom fee to be charged to sender or receiver.

**Related issue(s)**:

Fixes #81

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
