### PR TITLE
Add ECDSA(secp256k1) fields to Key and SignaturePair

### DIFF
--- a/src/main/proto/basic_types.proto
+++ b/src/main/proto/basic_types.proto
@@ -427,15 +427,40 @@ enum TokenKycStatus {
 }
 
 /**
- * A Key can be a public key from one of the three supported systems (ed25519, RSA-3072,  ECDSA with
- * p384). Or, it can be the ID of a smart contract instance, which is authorized to act as if it had
- * a key. If an account has an ed25519 key associated with it, then the corresponding private key
- * must sign any transaction to transfer cryptocurrency out of it. And similarly for RSA and ECDSA.
+ * Possible Pause statuses returned on TokenGetInfoQuery
+ */
+enum TokenPauseStatus {
+    /**
+     * Indicates that a Token has no pauseKey
+     */
+    PauseNotApplicable = 0;
+
+    /**
+     * Indicates that a Token is Paused
+     */
+    Paused = 1;
+
+    /**
+     * Indicates that a Token is Unpaused.
+     */
+    Unpaused = 2;
+}
+
+/**
+ * A Key can be a public key from either the Ed25519 or ECDSA(secp256k1) signature schemes, where
+ * in the ECDSA(secp256k1) case we require the 33-byte compressed form of the public key. We call
+ * these public keys <b>primitive keys</b>.
  *
- * A Key can be a smart contract ID, which means that smart contract is to authorize operations as
- * if it had signed with a key that it owned. The smart contract doesn't actually have a key, and
- * doesn't actually sign a transaction. But it's as if a virtual transaction were created, and the
- * smart contract signed it with a private key.
+ * If an account has primitive key associated to it, then the corresponding private key must sign
+ * any transaction to transfer cryptocurrency out of it.
+ *
+ * A Key can also be the ID of a smart contract instance, which is then authorized to perform any
+ * precompiled contract action that requires this key to sign.
+ *
+ * Note that when a Key is a smart contract ID, it <i>doesn't</i> mean the contract with that ID
+ * will actually create a cryptographic signature. It only means that when the contract calls a
+ * precompiled contract, the resulting "child transaction" will be authorized to perform any action
+ * controlled by the Key.
  *
  * A Key can be a "threshold key", which means a list of M keys, any N of which must sign in order
  * for the threshold signature to be considered valid. The keys within a threshold signature may
@@ -448,18 +473,16 @@ enum TokenKycStatus {
  * a transaction to delete the file. So it's a single list that sometimes acts as a 1-of-M threshold
  * key, and sometimes acts as an M-of-M threshold key.  A key list is always an M-of-M, unless
  * specified otherwise in documentation. A key list can have nested key lists or threshold keys.
- * Nested key lists are always M-of-M. A key list can have repeated Ed25519 public keys, but all
+ * Nested key lists are always M-of-M. A key list can have repeated primitive public keys, but all
  * repeated keys are only required to sign once.
  *
  * A Key can contain a ThresholdKey or KeyList, which in turn contain a Key, so this mutual
  * recursion would allow nesting arbitrarily deep. A ThresholdKey which contains a list of primitive
- * keys (e.g., ed25519) has 3 levels: ThresholdKey -> KeyList -> Key. A KeyList which contains
- * several primitive keys (e.g., ed25519) has 2 levels: KeyList -> Key. A Key with 2 levels of
- * nested ThresholdKeys has 7 levels: Key -> ThresholdKey -> KeyList -> Key -> ThresholdKey ->
- * KeyList -> Key.
+ * keys has 3 levels: ThresholdKey -> KeyList -> Key. A KeyList which contains several primitive
+ * keys has 2 levels: KeyList -> Key. A Key with 2 levels of nested ThresholdKeys has 7 levels:
+ * Key -> ThresholdKey -> KeyList -> Key -> ThresholdKey -> KeyList -> Key.
  *
  * Each Key should not have more than 46 levels, which implies 15 levels of nested ThresholdKeys.
- * Only ed25519 primitive keys are currently supported.
  */
 message Key {
     oneof key {
@@ -469,17 +492,17 @@ message Key {
         ContractID contractID = 1;
 
         /**
-         * ed25519 public key bytes
+         * Ed25519 public key bytes
          */
         bytes ed25519 = 2;
 
         /**
-         * RSA-3072 public key bytes
+         * (NOT SUPPORTED) RSA-3072 public key bytes
          */
         bytes RSA_3072 = 3;
 
         /**
-         * ECDSA with the p-384 curve public key bytes
+         * (NOT SUPPORTED) ECDSA with the p-384 curve public key bytes
          */
         bytes ECDSA_384 = 4;
 
@@ -493,6 +516,11 @@ message Key {
          * A list of Keys of the Key type.
          */
         KeyList keyList = 6;
+
+        /**
+         * Compressed ECDSA(secp256k1) public key bytes
+         */
+        bytes ECDSA_secp256k1 = 7;
     }
 }
 
@@ -528,27 +556,10 @@ message KeyList {
 }
 
 /**
- * A Signature corresponding to a Key. It is a sequence of bytes holding a public key signature from
- * one of the three supported systems (ed25519, RSA-3072,  ECDSA with p384). Or, it can be a list of
- * signatures corresponding to a single threshold key. Or, it can be the ID of a smart contract
- * instance, which is authorized to act as if it had a key. If an account has an ed25519 key
- * associated with it, then the corresponding private key must sign any transaction to transfer
- * cryptocurrency out of it.  If it has a smart contract ID associated with it, then that smart
- * contract is allowed to transfer cryptocurrency out of it. The smart contract doesn't actually
- * have a key, and  doesn't actually sign a transaction. But it's as if a virtual transaction were
- * created, and the smart contract signed it with a private key. A key can also be a "threshold
- * key", which means a list of M keys, any N of which must sign in order for the threshold signature
- * to be considered valid. The keys within a threshold signature may themselves be threshold
- * signatures, to allow complex signature requirements (this nesting is not supported in the
- * currently, but will be supported in a future version of API). If a Signature message is missing
- * the "signature" field, then this is considered to be a null signature. That is useful in cases
- * such as threshold signatures, where some of the signatures can be null.  The definition of Key
- * uses mutual recursion, so it allows nesting that is arbitrarily deep. But the current API only
- * accepts Key messages up to 3 levels deep, such as a list of threshold keys, each of which is a
- * list of primitive keys. Therefore, the matching Signature will have the same limitation. This
- * restriction may be relaxed in future versions of the API, to allow deeper nesting.
+ * This message is <b>DEPRECATED</b> and <b>UNUSABLE</b> with network nodes. It is retained
+ * here only for historical reasons.
  *
- * This message is deprecated and succeeded by SignaturePair and SignatureMap messages.
+ * Please use the SignaturePair and SignatureMap messages.
  */
 message Signature {
     option deprecated = true;
@@ -588,9 +599,10 @@ message Signature {
 }
 
 /**
- * A signature corresponding to a ThresholdKey. For an N-of-M threshold key, this is a list of M
- * signatures, at least N of which must be non-null.  This message is deprecated and succeeded by
- * SignaturePair and SignatureMap messages.
+ * This message is <b>DEPRECATED</b> and <b>UNUSABLE</b> with network nodes. It is retained
+ * here only for historical reasons.
+ *
+ * Please use the SignaturePair and SignatureMap messages.
  */
 message ThresholdSignature {
     option deprecated = true;
@@ -603,8 +615,10 @@ message ThresholdSignature {
 }
 
 /**
- * The signatures corresponding to a KeyList of the same length.  This message is deprecated and
- * succeeded by SignaturePair and SignatureMap messages.
+ * This message is <b>DEPRECATED</b> and <b>UNUSABLE</b> with network nodes. It is retained
+ * here only for historical reasons.
+ *
+ * Please use the SignaturePair and SignatureMap messages.
  */
 message SignatureList {
     option deprecated = true;
@@ -616,9 +630,17 @@ message SignatureList {
 }
 
 /**
- * The client may use any number of bytes from 0 to the whole length of the public key for
- * pubKeyPrefix.  If 0 bytes is used, then it is assumed that only one public key is used to sign.
- * Only ed25519 keys and hence signatures are currently supported. 
+ * The client may use any number of bytes from zero to the whole length of the public key for
+ * pubKeyPrefix. If zero bytes are used, then it must be that only one primitive key is required
+ * to sign the linked transaction; it will surely resolve to <tt>INVALID_SIGNATURE</tt> otherwise.
+ *
+ * <b>IMPORTANT:</b> In the special case that a signature is being provided for a key used to
+ * authorize a precompiled contract, the <tt>pubKeyPrefix</tt> must contain the <b>entire public
+ * key</b>! That is, if the key is a Ed25519 key, the <tt>pubKeyPrefix</tt> should be 32 bytes
+ * long. If the key is a ECDSA(secp256k1) key, the <tt>pubKeyPrefix</tt> should be 33 bytes long,
+ * since we require the compressed form of the public key.
+ *
+ * Only Ed25519 and ECDSA(secp256k1) keys and hence signatures are currently supported.
  */
 message SignaturePair {
     /**
@@ -646,6 +668,11 @@ message SignaturePair {
          * ECDSA p-384 signature
          */
         bytes ECDSA_384 = 5;
+
+        /**
+         * ECDSA(secp256k1) signature
+         */
+        bytes ECDSA_secp256k1 = 6;
     }
 }
 
@@ -986,6 +1013,16 @@ enum HederaFunctionality {
      * Get execution time(s) by TransactionID, if available
      */
     NetworkGetExecutionTime = 78;
+
+    /**
+     * Pause the Token
+     */
+    TokenPause = 79;
+
+    /**
+     * Unpause the Token
+     */
+    TokenUnpause = 80;
 }
 
 /**
@@ -1153,7 +1190,7 @@ message ServiceEndpoint {
 /**
  * The data about a node, including its service endpoints and the Hedera account to be paid for
  * services provided by the node (that is, queries answered and transactions submitted.)
- * 
+ *
  * If the <tt>serviceEndpoint</tt> list is not set, or empty, then the endpoint given by the
  * (deprecated) <tt>ipAddress</tt> and <tt>portno</tt> fields should be used.
  *
@@ -1179,7 +1216,9 @@ message NodeAddress {
     bytes memo = 3 [deprecated=true];
 
     /**
-     * The node's hex-encoded X509 RSA public key
+     * The node's X509 RSA public key used to sign stream files (e.g., record stream
+     * files). Precisely, this field is a string of hexadecimal characters which,
+     * translated to binary, are the public key's DER encoding.
      */
     string RSA_PubKey = 4;
 
@@ -1194,7 +1233,10 @@ message NodeAddress {
     AccountID nodeAccountId = 6;
 
     /**
-     * # The hex-encoded SHA-384 hash of the X509 cert used to encrypt gRPC traffic to the node
+     * # Hash of the node's TLS certificate. Precisely, this field is a string of
+     * hexadecimal characters which, translated to binary, are the SHA-384 hash of
+     * the UTF-8 NFKD encoding of the node's TLS cert in PEM format. Its value can be
+     * used to verify the node's certificate it presents during TLS negotiations.
      */
     bytes nodeCertHash = 7;
 


### PR DESCRIPTION
Signed-off-by: Neeharika-Sompalli <neeharika.sompalli@hedera.com>

**Closed PR in [Hedera protobufs](https://github.com/hashgraph/hedera-protobufs/pull/115)**
Closes #102 

Description:

1. Adds fields for ECDSA(secp256k1) public keys and signatures to the Key and SignaturePair types, respectively.
2. Updates comments to reflect that only these two cryptography schemes are actually supported.
