### PR TITLE
Changes for Auto Account Creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.hedera.hashgraph</groupId>
   <artifactId>hedera-protobuf-java-api</artifactId>
   <packaging>jar</packaging>
-  <version>0.20.0-SNAPSHOT</version>
+  <version>0.21.0-auto-account-create</version>
 
   <name>hedera-protobuf-java-api</name>
   <description>Hedera Protobuf Java API</description>

--- a/src/main/proto/basic_types.proto
+++ b/src/main/proto/basic_types.proto
@@ -79,13 +79,35 @@ message AccountID {
     int64 realmNum = 2;
 
     /**
-     * A nonnegative account number unique within its realm
+     * The account number unique within its realm which can be either a non-negative integer or an alias public key.
+     * For any AccountID fields in the query response, transaction record or transaction receipt only accountNum will
+     * be populated.
      */
-    int64 accountNum = 3;
+    oneof account {
+
+        /**
+         * A non-negative account number unique within its realm
+         */
+        int64 accountNum = 3;
+
+        /**
+         * A public key to be used as the account's alias. Only a primitive key is supported as an alias Key
+         * (ThresholdKey and KeyList are not supported).
+         *
+         * At most one account can ever have a given alias and it is used for account creation if it
+         * was automatically created using a crypto transfer. It will be null if an account is created normally.
+         * It is immutable once it is set for an account.
+         *
+         * If a transaction auto-creates the account, any further transfers to that alias will simply be deposited
+         * in that account, without creating anything, and with no creation fee being charged.
+         */
+        Key alias = 4;
+    }
+
 }
 
 /**
- * The ID for a file 
+ * The ID for a file
  */
 message FileID {
     /**
@@ -105,7 +127,7 @@ message FileID {
 }
 
 /**
- * The ID for a smart contract instance 
+ * The ID for a smart contract instance
  */
 message ContractID {
     /**
@@ -329,19 +351,19 @@ enum TokenType {
 }
 
 /**
- * Allows a set of resource prices to be scoped to a certain type of a HAPI operation. 
- * 
+ * Allows a set of resource prices to be scoped to a certain type of a HAPI operation.
+ *
  * For example, the resource prices for a TokenMint operation are different between minting fungible
  * and non-fungible tokens. This enum allows us to "mark" a set of prices as applying to one or the
  * other.
- * 
+ *
  * Similarly, the resource prices for a basic TokenCreate without a custom fee schedule yield a
  * total price of $1. The resource prices for a TokenCreate with a custom fee schedule are different
  * and yield a total base price of $2.
  */
 enum SubType {
     /**
-     * The resource prices have no special scope 
+     * The resource prices have no special scope
      */
     DEFAULT = 0;
 

--- a/src/main/proto/basic_types.proto
+++ b/src/main/proto/basic_types.proto
@@ -65,7 +65,7 @@ message RealmID {
 }
 
 /**
- * The ID for an a cryptocurrency account 
+ * The ID for an a cryptocurrency account
  */
 message AccountID {
     /**
@@ -91,8 +91,9 @@ message AccountID {
         int64 accountNum = 3;
 
         /**
-         * A public key to be used as the account's alias. Only a primitive key is supported as an alias Key
-         * (ThresholdKey and KeyList are not supported).
+         * The public key bytes to be used as the account's alias. The public key bytes are the result of serializing
+         * a protobuf Key message for any primitive key type. Currently only primitive key bytes are supported as an alias
+         * (ThresholdKey, KeyList, ContractID, and delegatable_contract_id are not supported)
          *
          * At most one account can ever have a given alias and it is used for account creation if it
          * was automatically created using a crypto transfer. It will be null if an account is created normally.
@@ -101,7 +102,7 @@ message AccountID {
          * If a transaction auto-creates the account, any further transfers to that alias will simply be deposited
          * in that account, without creating anything, and with no creation fee being charged.
          */
-        Key alias = 4;
+        bytes alias = 4;
     }
 
 }
@@ -1442,19 +1443,4 @@ message TokenBalances {
 message TokenAssociation {
     TokenID token_id = 1;  // The token involved in the association
     AccountID account_id = 2; // The account involved in the association
-}
-
-/**
- * An account and its corresponding alias
- */
-message AccountAlias {
-    /**
-     * Alias for given account
-     */
-    Key alias = 1;
-
-    /**
-     * Account auto-created because of a CryptoTransfer to the alias
-     */
-    AccountID account = 2;
 }

--- a/src/main/proto/basic_types.proto
+++ b/src/main/proto/basic_types.proto
@@ -1443,3 +1443,18 @@ message TokenAssociation {
     TokenID token_id = 1;  // The token involved in the association
     AccountID account_id = 2; // The account involved in the association
 }
+
+/**
+ * An account and its corresponding alias
+ */
+message AccountAlias {
+    /**
+     * Alias for given account
+     */
+    Key alias = 1;
+
+    /**
+     * Account auto-created because of a CryptoTransfer to the alias
+     */
+    AccountID account = 2;
+}

--- a/src/main/proto/crypto_get_info.proto
+++ b/src/main/proto/crypto_get_info.proto
@@ -157,6 +157,11 @@ message CryptoGetInfoResponse {
          * The maximum number of tokens that an Account can be implicitly associated with.
          */
         int32 max_automatic_token_associations = 18;
+
+        /**
+         * The alias of this account
+         */
+        bytes alias = 19;
     }
 
     /**

--- a/src/main/proto/transaction_record.proto
+++ b/src/main/proto/transaction_record.proto
@@ -110,4 +110,9 @@ message TransactionRecord {
      * All token associations implicitly created while handling this transaction
      */
     repeated TokenAssociation automatic_token_associations = 14;
+
+    /**
+     * All accounts auto-created because of a CryptoTransfer transaction to the corresponding alias
+     */
+    repeated AccountAlias new_account_aliases = 15;
 }


### PR DESCRIPTION
**Closed PR in [Hedera protobufs](https://github.com/hashgraph/hedera-protobufs/pull/119)**

**Description**:
Protobuf changes to support auto account creation. 
1. Adds an `alias` Key field for AccountID. Any account can have either accountNum or an alias
2. Modified `AccountInfo` to have `bytes alias` 
3. Added a map of alias and account number pairs in `transaction_record`

**Related issue(s)**:
Fixes #104 
