### PR TITLE
Pom fix for v60

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.hedera.hashgraph</groupId>
   <artifactId>hedera-protobuf-java-api</artifactId>
   <packaging>jar</packaging>
-  <version>0.60.1-SNAPSHOT</version>
+  <version>0.60.0-SNAPSHOT</version>
 
   <name>hedera-protobuf-java-api</name>
   <description>Hedera Protobuf Java API</description>
@@ -31,7 +31,7 @@
     <developerConnection>scm:git:git@github.com:hashgraph/hedera-protobuf.git</developerConnection>
     <url>https://github.com/hashgraph/hedera-protobuf</url>
     <!-- Note: This is not the tag we are pulling from hedera-protobufs, but is the target tag we are creating in this repo -->
-    <tag>v0.59.1</tag>
+    <tag>v0.60.0</tag>
   </scm>
 
   <distributionManagement>


### PR DESCRIPTION
Bumps the `<tag>` version to v0.60.0 and resets the pom version to `v0.60.0-SNAPSHOT`